### PR TITLE
obs-530: update os image for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,18 +3,15 @@
 
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Set the version of Python and other tools you might need
-build:
-  os: ubuntu-20.04
-  tools:
-    python: "3.9"
-
-# Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
 
 python:
   install:


### PR DESCRIPTION
We already specify the location of the configuration file, but this moves it to the same place in the file that we use for our services. I updated the OS image to 22.04.